### PR TITLE
Make session in searchSchema configurable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -341,8 +341,14 @@ export const assertSchema = ({
   });
 };
 
-export const searchSchema = async ({ driver, schema, debug = false }) => {
-  const session = driver.session();
+export const searchSchema = async ({
+  driver,
+  schema,
+  debug = false,
+  sessionParams = {}
+}) => {
+  const session = driver.session(sessionParams);
+
   // drop all search indexes, given they cannot be updated via a second CALL to createNodeIndex
   const dropStatement = `
   CALL db.indexes() YIELD name, provider WHERE provider = "fulltext-1.0"


### PR DESCRIPTION
This change solves https://github.com/neo4j-graphql/neo4j-graphql-js/issues/570, by adding `sessionParams` as a parameter to the `searchSchema` function. 

When working on a multi-database project, searchSchema could be used like this to target a non-default database `foo`:

```js
searchSchema(driver, schema, sessionParams: { database: 'foo' })
```

Upstream PR: https://github.com/neo4j-graphql/neo4j-graphql-js/pull/577